### PR TITLE
Change repositoryUrl from SSH to HTTP

### DIFF
--- a/KS.Fiks.Crypto/KS.Fiks.Crypto.csproj
+++ b/KS.Fiks.Crypto/KS.Fiks.Crypto.csproj
@@ -9,7 +9,7 @@
         <PackageProjectUrl>https://github.com/ks-no/kryptering-dotnet</PackageProjectUrl>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageIcon>KS.png</PackageIcon>
-        <RepositoryUrl>git@github.com:ks-no/kryptering-dotnet.git</RepositoryUrl>
+        <RepositoryUrl>https://github.com/ks-no/kryptering-dotnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>FIKS</PackageTags>
         <VersionPrefix>2.0.2</VersionPrefix>


### PR DESCRIPTION
Dette førte til at schema validation under opplasting av bom.json til DependencyTrack feilet for alle prosjekter som bruker denne pakken, blant annet fiks-io-client-dotnet og fiks-io-client-encryption-dotnet. SSH-lenken var ikke gyldig URL.