### PR TITLE
Netstandard2.0

### DIFF
--- a/KS.Fiks.Crypto/KS.Fiks.Crypto.csproj
+++ b/KS.Fiks.Crypto/KS.Fiks.Crypto.csproj
@@ -17,8 +17,6 @@
         <TargetFrameworks>net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <AssemblyVersion>3.0.0.0</AssemblyVersion>
-        <FileVersion>3.0.0.0</FileVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/KS.Fiks.Crypto/KS.Fiks.Crypto.csproj
+++ b/KS.Fiks.Crypto/KS.Fiks.Crypto.csproj
@@ -14,7 +14,7 @@
         <PackageTags>FIKS</PackageTags>
         <VersionPrefix>3.0.1</VersionPrefix>
         <PackageIconUrl>https://ks-no.github.io/images/favicon.png</PackageIconUrl>
-        <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/KS.Fiks.Crypto/KS.Fiks.Crypto.csproj
+++ b/KS.Fiks.Crypto/KS.Fiks.Crypto.csproj
@@ -17,6 +17,8 @@
         <TargetFrameworks>net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <AssemblyVersion>3.0.0.0</AssemblyVersion>
+        <FileVersion>3.0.0.0</FileVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Common encryption and decryption logic required by various KS FIKS clients on th
 All crypto is performed using a portable C# version of the [BouncyCastle library](https://www.bouncycastle.org/csharp/)
 
 ## Prerequisites
-* This library targets _.Net Core 3.1_ as well as _.Net Standard 2.1_
+* This library targets _.Net Core 3.1_ as well as _.Net Standard 2.1_ and _.Net Standard 2.0_.
 * A PEM file containing the BASE64 encoded public certificate to be used for encryption
 * A PEM file containing the BASE64 encoded private key to be used for decryption
 


### PR DESCRIPTION
**Hvorfor er dette gjort?**
Vi er nødt til å støtte netstandard 2.0 i fiks-io klienten dotnet. Noen av konsumentene er på .NET 4.8. Som gjør at vi er nødt til å støtte dette.

**Hva er gjort:**

La inn støtte for netstandard 2.0. Readme er også oppdatert.